### PR TITLE
remove email button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,121 +1,195 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=News+Cycle&display=swap"
-        rel="stylesheet">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=News+Cycle&display=swap"
+      rel="stylesheet"
+    />
 
     <!-- Primary Meta Tags -->
     <title>Trianglify Generator - Free trianglify generator</title>
-    <meta name="title" content="Trianglify Generator - Free trianglify generator">
-    <meta name="description"
-        content="A free, fast, and open-source generator for trianglify.js with no coding required to create low-poly images, perfect for wallpapers and insert stuff here.">
+    <meta
+      name="title"
+      content="Trianglify Generator - Free trianglify generator"
+    />
+    <meta
+      name="description"
+      content="A free, fast, and open-source generator for trianglify.js with no coding required to create low-poly images, perfect for wallpapers and insert stuff here."
+    />
 
     <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://trianglify.netlify.app/">
-    <meta property="og:title" content="Trianglify Generator - Free trianglify generator">
-    <meta property="og:description"
-        content="A free, fast, and open-source generator for trianglify.js with no coding required to create low-poly images, perfect for wallpapers and insert stuff here.">
-    <meta property="og:image" content="favicon/logo.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://trianglify.netlify.app/" />
+    <meta
+      property="og:title"
+      content="Trianglify Generator - Free trianglify generator"
+    />
+    <meta
+      property="og:description"
+      content="A free, fast, and open-source generator for trianglify.js with no coding required to create low-poly images, perfect for wallpapers and insert stuff here."
+    />
+    <meta property="og:image" content="favicon/logo.svg" />
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://trianglify.netlify.app/">
-    <meta property="twitter:title" content="Trianglify Generator - Free trianglify generator">
-    <meta property="twitter:description"
-        content="A free, fast, and open-source generator for trianglify.js with no coding required to create low-poly images, perfect for wallpapers and insert stuff here.">
-    <meta property="twitter:image" content="favicon/logo.svg">
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://trianglify.netlify.app/" />
+    <meta
+      property="twitter:title"
+      content="Trianglify Generator - Free trianglify generator"
+    />
+    <meta
+      property="twitter:description"
+      content="A free, fast, and open-source generator for trianglify.js with no coding required to create low-poly images, perfect for wallpapers and insert stuff here."
+    />
+    <meta property="twitter:image" content="favicon/logo.svg" />
 
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="manifest.json">
-</head>
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="favicon/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="favicon/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="favicon/favicon-16x16.png"
+    />
+    <link rel="manifest" href="manifest.json" />
+  </head>
 
-<body>
-    <a href="https://github.com/realcyguy/trianglify-generator" class="github-corner"
-        aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250"
-            style="fill:#fa7c59; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
-            <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
-            <path
-                d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
-                fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
-            <path
-                d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
-                fill="currentColor" class="octo-body"></path>
-        </svg></a>
+  <body>
+    <a
+      href="https://github.com/realcyguy/trianglify-generator"
+      class="github-corner"
+      aria-label="View source on GitHub"
+      ><svg
+        width="80"
+        height="80"
+        viewBox="0 0 250 250"
+        style="
+          fill: #fa7c59;
+          color: #fff;
+          position: absolute;
+          top: 0;
+          border: 0;
+          right: 0;
+        "
+        aria-hidden="true"
+      >
+        <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+        <path
+          d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+          fill="currentColor"
+          style="transform-origin: 130px 106px"
+          class="octo-arm"
+        ></path>
+        <path
+          d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+          fill="currentColor"
+          class="octo-body"
+        ></path></svg
+    ></a>
     <header>
-        <h1>Trianglify Generator</h1>
-        <p>A free generator for <a href="https://trianglify.io">trianglify.js</a> made by Cyrus. Go make low-poly images
-            to be used as wallpapers or whatever! Open source on <a
-                href="https://github.com/realcyguy/trianglify-generator">github</a>.</p>
+      <h1>Trianglify Generator</h1>
+      <p>
+        A free generator for
+        <a href="https://trianglify.io">trianglify.js</a> made by Cyrus. Go make
+        low-poly images to be used as wallpapers or whatever! Open source on
+        <a href="https://github.com/realcyguy/trianglify-generator">github</a>.
+      </p>
     </header>
     <form id="form">
-        <div class="form-top">
-            <div>
-                <label for="width">Width</label>
-                <input id="width" type="number" name="width" value="600">
-            </div>
-            <div>
-                <label for="height">Height</label>
-                <input id="height" type="number" name="height" value="400">
-            </div>
-            <div>
-                <label for="cell">Cell Size</label>
-                <input id="cell" type="number" name="cell" value="75">
-            </div>
-            <div>
-                <label for="variance">Variance</label>
-                <input id="variance" type="number" name="variance" value="0.75" step="0.01" min="0" max="1">
-            </div>
+      <div class="form-top">
+        <div>
+          <label for="width">Width</label>
+          <input id="width" type="number" name="width" value="600" />
         </div>
-        <hr>
-        <div class="buttons">
-            <button id="regenerate">Regenerate</button>
-            <button id="addcolour">Add colour</button>
-            <button id="addrandomcolour">Add random colour</button>
-            <button id="removeallcolour">Remove all colours</button>
-            <button id="exportcolour">Export colours</button>
-            <button id="importcolour">Import colours</button>
+        <div>
+          <label for="height">Height</label>
+          <input id="height" type="number" name="height" value="400" />
         </div>
-        <div class="colours">
-            <div class='colourinput'>
-                <input type='color' class='colour' value='#e52165'>
-                <button class='x'>X</button>
-            </div>
-            <div class='colourinput'>
-                <input type='color' class='colour' value='#93cccc'>
-                <button class='x'>X</button>
-            </div>
+        <div>
+          <label for="cell">Cell Size</label>
+          <input id="cell" type="number" name="cell" value="75" />
         </div>
+        <div>
+          <label for="variance">Variance</label>
+          <input
+            id="variance"
+            type="number"
+            name="variance"
+            value="0.75"
+            step="0.01"
+            min="0"
+            max="1"
+          />
+        </div>
+      </div>
+      <hr />
+      <div class="buttons">
+        <button id="regenerate">Regenerate</button>
+        <button id="addcolour">Add colour</button>
+        <button id="addrandomcolour">Add random colour</button>
+        <button id="removeallcolour">Remove all colours</button>
+        <button id="exportcolour">Export colours</button>
+        <button id="importcolour">Import colours</button>
+      </div>
+      <div class="colours">
+        <div class="colourinput">
+          <input type="color" class="colour" value="#e52165" />
+          <button class="x">X</button>
+        </div>
+        <div class="colourinput">
+          <input type="color" class="colour" value="#93cccc" />
+          <button class="x">X</button>
+        </div>
+      </div>
     </form>
     <canvas></canvas>
     <div class="download">
-        <p>Download as:</p>
-        <div class="download-links"></div>
+      <p>Download as:</p>
+      <div class="download-links"></div>
     </div>
     <footer>
-        <p>made with <span class="heart">heart emoji</span> by <a href="https://realcyguy.netlify.app">cyrus yip</a></p>
-        <hr>
-        <p>Share:</p>
-        <div class="share">
-            <a href="https://twitter.com/intent/tweet?text=Hey,%20hey!%20Did%20you%20hear%20about%20the%20amaaaaaazzing%20tool%3A%20Trianglify%20Generator?%20You%20can%20create%20low-poly%20triangle%20images%20to%20be%20used%20for%20wallpapers,%20etc!%20Best%20of%20all,%20it's%20100%25%20free%20and%20open%20source!%20Check%20it%20out%20here%20at%20this%20link%3A%20https%3A//trianglify.netlify.app%20Peace%20out!%20%23blessed%20%23thanksgod">Twitter</a>
-            <a href="http://reddit.com/submit?url=https%3A%2F%2Ftrianglify.netlify.app&title=Trianglify%20Generator">Reddit</a>
-            <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A//trianglify.netlify.app">Facebook</a>
-            <a href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A//trianglify.netlify.app">LinkedIn</a>
-            <a href="mailto:?body=Hey%20friend,%0A%0AYou%20should%20check%20this%20out%3A%0Ahttps%3A//trianglify.netlify.app%0A%0ASincerely,%0AOne%20of%20your%20dearest%20friends.">Email</a>
-            <a class="copy">Copy Link</a>
-        </div>
+      <p>
+        made with <span class="heart">heart emoji</span> by
+        <a href="https://realcyguy.netlify.app">cyrus yip</a>
+      </p>
+      <hr />
+      <p>Share:</p>
+      <div class="share">
+        <a
+          href="https://twitter.com/intent/tweet?text=Hey,%20hey!%20Did%20you%20hear%20about%20the%20amaaaaaazzing%20tool%3A%20Trianglify%20Generator?%20You%20can%20create%20low-poly%20triangle%20images%20to%20be%20used%20for%20wallpapers,%20etc!%20Best%20of%20all,%20it's%20100%25%20free%20and%20open%20source!%20Check%20it%20out%20here%20at%20this%20link%3A%20https%3A//trianglify.netlify.app%20Peace%20out!%20%23blessed%20%23thanksgod"
+          >Twitter</a
+        >
+        <a
+          href="http://reddit.com/submit?url=https%3A%2F%2Ftrianglify.netlify.app&title=Trianglify%20Generator"
+          >Reddit</a
+        >
+        <a
+          href="https://www.facebook.com/sharer/sharer.php?u=https%3A//trianglify.netlify.app"
+          >Facebook</a
+        >
+        <a
+          href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A//trianglify.netlify.app"
+          >LinkedIn</a
+        >
+        <a class="copy">Copy Link</a>
+      </div>
     </footer>
 
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/trianglify/2.0.0/trianglify.min.js'></script>
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js'></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/trianglify/2.0.0/trianglify.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
     <script src="script.js"></script>
-</body>
-
+  </body>
 </html>


### PR DESCRIPTION
The email button did not work so I am proposing to remove the button entirely. This would make a great addition to the website as it protects people from false hope. When people see the button they have an expectation that the button will send an email about the trianglify website but they get greeted by nothing. Sorrow then comes into play and the person who tried to press the email button is now depressed.